### PR TITLE
[Autopilot approval] openstorage.io.action.volume/resize postgres-pvc

### DIFF
--- a/aut-approvals/yaml-test-aro/.yaml
+++ b/aut-approvals/yaml-test-aro/.yaml
@@ -11,7 +11,7 @@ metadata:
     controller: true
     kind: AutopilotRule
     name: yaml-test-rule
-    uid: 12a43a5c-df07-435f-855e-2dd5dfb380c5
+    uid: 8ff68f5a-98a5-4b77-aa39-3504be4f8e43
 spec:
   actionApprovals:
   - action:
@@ -39,18 +39,18 @@ spec:
     state: pending
 status:
   items:
-  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+  - lastProcessTimestamp: "2020-04-10T17:43:40Z"
     message: random 0 message
     state: Normal
-  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+  - lastProcessTimestamp: "2020-04-10T17:43:40Z"
     message: random 1 message
     state: Normal
-  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+  - lastProcessTimestamp: "2020-04-10T17:43:40Z"
     message: random 2 message
     state: Normal
-  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+  - lastProcessTimestamp: "2020-04-10T17:43:40Z"
     message: random 3 message
     state: Normal
-  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+  - lastProcessTimestamp: "2020-04-10T17:43:40Z"
     message: random 4 message
     state: Normal

--- a/aut-approvals/yaml-test-aro/.yaml
+++ b/aut-approvals/yaml-test-aro/.yaml
@@ -1,0 +1,56 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: yaml-test-rule
+  name: yaml-test-aro
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: yaml-test-rule
+    uid: 12a43a5c-df07-435f-855e-2dd5dfb380c5
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 10 GiB to 20 GiB
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          rule: aut-test-rule
+          ruleobject: pvc-d94b06a1-c88c-42d4-a494-99f1c43c0915
+        creationTimestamp: null
+        labels:
+          type: db
+        name: postgres-pvc
+        namespace: postgres-ns
+        ownerReferences:
+        - apiVersion: apps/v1
+          controller: true
+          kind: Deployment
+          name: postgres
+          uid: ""
+        uid: pvc-d94b06a1-c88c-42d4-a494-99f1c43c0915
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    state: pending
+status:
+  items:
+  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+    message: random 0 message
+    state: Normal
+  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+    message: random 1 message
+    state: Normal
+  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+    message: random 2 message
+    state: Normal
+  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+    message: random 3 message
+    state: Normal
+  - lastProcessTimestamp: "2020-04-10T17:35:11Z"
+    message: random 4 message
+    state: Normal


### PR DESCRIPTION


This is a request to approve the following automated action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: postgres-pvc
- **Namespace**: postgres-ns
- **Owner information**:
    - **Type**: Deployment
    - **Name**: postgres

### What action will be taken

PVC will resize from 10 GiB to 20 GiB

### Why is the action needed.

The action request was triggered based on an AutopilotRule aut-test-rule defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.