### PR TITLE
[Autopilot approval] openstorage.io.action.volume/resize pgbench-data

### DIFF
--- a/workloads/pvc-d94b06a1-c88c-42d4-a494-99f1c43c0915.yaml
+++ b/workloads/pvc-d94b06a1-c88c-42d4-a494-99f1c43c0915.yaml
@@ -1,0 +1,58 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: "2020-04-10T22:54:47Z"
+  generation: 2
+  labels:
+    rule: volume-resize
+  name: pvc-d94b06a1-c88c-42d4-a494-99f1c43c0915
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 2c022ff8-9b59-4e58-ae6f-e7e9fadd10a6
+  resourceVersion: "2384446"
+  selfLink: /apis/autopilot.libopenstorage.org/v1alpha1/autopilotruleobjects/pvc-d94b06a1-c88c-42d4-a494-99f1c43c0915
+  uid: 0f08e29a-f98e-4f41-a8e3-b81040e69b5f
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 20Gi to 40Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"default"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-d94b06a1-c88c-42d4-a494-99f1c43c0915
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+          volume.kubernetes.io/storage-resizer: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: default
+        ownerReferences:
+        - apiVersion: apps/v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ReplicaSet
+          name: pgbench-5f84f5b884
+          uid: 3ea649f3-61ac-4f21-a60b-7ed033509f2b
+        selfLink: /api/v1/namespaces/default/persistentvolumeclaims/pgbench-data
+        uid: d94b06a1-c88c-42d4-a494-99f1c43c0915
+      params:
+        scalepercentage: "100"
+    state: approved
+status:
+  items:
+  - lastProcessTimestamp: "2020-04-10T22:54:47Z"
+    message: 'rule: volume-resize:pvc-d94b06a1-c88c-42d4-a494-99f1c43c0915 transition
+      from Normal => Triggered'
+    state: Triggered
+  - lastProcessTimestamp: "2020-04-10T22:55:00Z"
+    message: 'rule: volume-resize:pvc-d94b06a1-c88c-42d4-a494-99f1c43c0915 transition
+      from Triggered => ActionAwaitingApproval'
+    state: ActionAwaitingApproval


### PR DESCRIPTION


This is a request to approve the following automated action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: default
- **Owner information**:
    - **Type**: ReplicaSet
    - **Name**: pgbench-5f84f5b884

### What action will be taken

PVC will resize from 20Gi to 40Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.