### PR TITLE
[Autopilot] resize approval for db/postgres-data (pvc-0289ff0b-882e-4662-b5d9-cd924df12fcf) rule: ut-vol-resize-rule

### DIFF
--- a/workloads/pvc-0289ff0b-882e-4662-b5d9-cd924df12fcf.yaml
+++ b/workloads/pvc-0289ff0b-882e-4662-b5d9-cd924df12fcf.yaml
@@ -1,0 +1,57 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: ut-vol-resize-rule
+  name: pvc-0289ff0b-882e-4662-b5d9-cd924df12fcf
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: ut-vol-resize-rule
+    uid: ab202745-8ceb-4c59-a319-58a830f65588
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 10 GiB to 20 GiB
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          rule: ut-vol-resize-rule
+          ruleobject: pvc-0289ff0b-882e-4662-b5d9-cd924df12fcf
+        creationTimestamp: null
+        labels:
+          type: db
+        name: postgres-data
+        namespace: db
+        ownerReferences:
+        - apiVersion: apps/v1
+          controller: true
+          kind: Deployment
+          name: postgres
+          uid: ""
+        type: PersistentVolumeClaim
+        uid: pvc-0289ff0b-882e-4662-b5d9-cd924df12fcf
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    state: approved
+status:
+  items:
+  - lastProcessTimestamp: "2020-04-15T01:53:59Z"
+    message: random 0 message
+    state: Normal
+  - lastProcessTimestamp: "2020-04-15T01:53:59Z"
+    message: random 1 message
+    state: Normal
+  - lastProcessTimestamp: "2020-04-15T01:53:59Z"
+    message: random 2 message
+    state: Normal
+  - lastProcessTimestamp: "2020-04-15T01:53:59Z"
+    message: random 3 message
+    state: Normal
+  - lastProcessTimestamp: "2020-04-15T01:53:59Z"
+    message: random 4 message
+    state: Normal


### PR DESCRIPTION


This is a request to approve the following automated action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: postgres-data
- **Namespace**: db
- **Owner information**:
    - **Type**: Deployment
    - **Name**: postgres

### What action will be taken

PVC will resize from 10 GiB to 20 GiB

### Why is the action needed.

The action request was triggered based on an AutopilotRule ut-vol-resize-rule defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.