### PR TITLE
[Autopilot] resize approval for default/pgbench-data (pvc-ddfb4003-0a90-425b-a232-debf61299be0) rule: volume-resize

### DIFF
--- a/workloads/pvc-ddfb4003-0a90-425b-a232-debf61299be0-c77070bc-73b1-4359-b34e-cad64d55a567.yaml
+++ b/workloads/pvc-ddfb4003-0a90-425b-a232-debf61299be0-c77070bc-73b1-4359-b34e-cad64d55a567.yaml
@@ -1,0 +1,50 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: 72b1959380f38444a633aa58e22b63a72d0b4327
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.3orindubcr2d2CnQbDp2pmjdWeUp6I6ryUR2ByxPtTo
+    rule: volume-resize
+  name: pvc-ddfb4003-0a90-425b-a232-debf61299be0
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: 93d3424e-6dee-459c-a91e-b194e9d8771a
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 40Gi to 80Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"default"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-ddfb4003-0a90-425b-a232-debf61299be0
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+          volume.kubernetes.io/storage-resizer: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: default
+        ownerReferences:
+        - apiVersion: apps/v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ReplicaSet
+          name: pgbench-5f84f5b884
+          uid: 3018edf8-efb3-40c5-b77c-6e5dfc76f055
+        selfLink: /api/v1/namespaces/default/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: ddfb4003-0a90-425b-a232-debf61299be0
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: default
- **Owner information**:
    - **Type**: ReplicaSet
    - **Name**: pgbench-5f84f5b884

### What action will be taken

PVC will resize from 40Gi to 80Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.