### PR TITLE
[Autopilot] resize approval for pg2/pgbench-data (pvc-be586e45-7337-43e5-b347-8e17f4be20ac) rule: volume-resize

### DIFF
--- a/workloads/pvc-be586e45-7337-43e5-b347-8e17f4be20ac-1e5fd878-b49b-4127-9621-f2cbc54ba5ee.yaml
+++ b/workloads/pvc-be586e45-7337-43e5-b347-8e17f4be20ac-1e5fd878-b49b-4127-9621-f2cbc54ba5ee.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-be586e45-7337-43e5-b347-8e17f4be20ac
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: d4112531-0585-4be8-a9fd-bcd6d7b278ad
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg2"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-be586e45-7337-43e5-b347-8e17f4be20ac
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg2
+        selfLink: /api/v1/namespaces/pg2/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: be586e45-7337-43e5-b347-8e17f4be20ac
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: pg2
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 3Gi to 6Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
