### PR TITLE
[Autopilot] resize approval for pg3/pgbench-data (pvc-d119c2c9-f4cc-4965-bc47-ee3333ec33e9) rule: volume-resize

### DIFF
--- a/workloads/pvc-d119c2c9-f4cc-4965-bc47-ee3333ec33e9-28c9883c-e774-4e62-81fa-09af5c8fcc98.yaml
+++ b/workloads/pvc-d119c2c9-f4cc-4965-bc47-ee3333ec33e9-28c9883c-e774-4e62-81fa-09af5c8fcc98.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-d119c2c9-f4cc-4965-bc47-ee3333ec33e9
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: cc2788e0-cfdf-4e9a-ab70-73bd8ef0a6c7
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg3"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-d119c2c9-f4cc-4965-bc47-ee3333ec33e9
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg3
+        selfLink: /api/v1/namespaces/pg3/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: d119c2c9-f4cc-4965-bc47-ee3333ec33e9
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: pg3
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 3Gi to 6Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
