### PR TITLE
[Autopilot] resize approval for pg3/pgbench-data (pvc-b56f4d44-e804-411a-adef-88c0834f97f6) rule: volume-resize

### DIFF
--- a/workloads/pvc-b56f4d44-e804-411a-adef-88c0834f97f6-73f43ecb-d06d-491e-bc55-f5894921f0df.yaml
+++ b/workloads/pvc-b56f4d44-e804-411a-adef-88c0834f97f6-73f43ecb-d06d-491e-bc55-f5894921f0df.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-b56f4d44-e804-411a-adef-88c0834f97f6
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: dfd0aeb2-ae9e-499c-8cd1-ac0dca6e3d62
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg3"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-b56f4d44-e804-411a-adef-88c0834f97f6
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg3
+        selfLink: /api/v1/namespaces/pg3/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: b56f4d44-e804-411a-adef-88c0834f97f6
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: pg3
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 3Gi to 6Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
