### PR TITLE
[Autopilot] resize approval for pg2/pgbench-data (pvc-f4a5ba8c-d43a-4bfd-8507-d101ff5bac8c) rule: volume-resize

### DIFF
--- a/workloads/pvc-f4a5ba8c-d43a-4bfd-8507-d101ff5bac8c-da22ffae-6ee4-45aa-9f1e-7f7fdef3f87b.yaml
+++ b/workloads/pvc-f4a5ba8c-d43a-4bfd-8507-d101ff5bac8c-da22ffae-6ee4-45aa-9f1e-7f7fdef3f87b.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-f4a5ba8c-d43a-4bfd-8507-d101ff5bac8c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: 5427eab7-5847-440d-890d-d92125684587
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg2"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-f4a5ba8c-d43a-4bfd-8507-d101ff5bac8c
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg2
+        selfLink: /api/v1/namespaces/pg2/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: f4a5ba8c-d43a-4bfd-8507-d101ff5bac8c
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: pg2
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 3Gi to 6Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
