### PR TITLE
[Autopilot] resize approval for pg3/pgbench-data (pvc-d05e6f4f-162e-4aa9-900d-99d16d2600e1) rule: volume-resize

### DIFF
--- a/workloads/pvc-d05e6f4f-162e-4aa9-900d-99d16d2600e1-10fe8776-ad58-4c72-bc95-35ea8cf7f218.yaml
+++ b/workloads/pvc-d05e6f4f-162e-4aa9-900d-99d16d2600e1-10fe8776-ad58-4c72-bc95-35ea8cf7f218.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-d05e6f4f-162e-4aa9-900d-99d16d2600e1
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: d0a0ba80-298d-4c13-8a4c-ed88baf7e4dd
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg3"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-d05e6f4f-162e-4aa9-900d-99d16d2600e1
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg3
+        selfLink: /api/v1/namespaces/pg3/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: d05e6f4f-162e-4aa9-900d-99d16d2600e1
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: pg3
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 3Gi to 6Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
