### PR TITLE
[Autopilot] resize approval for pg1/pgbench-data (pvc-997b2378-04e0-4b7e-970d-03ebedb7c2e7) rule: volume-resize

### DIFF
--- a/workloads/pvc-997b2378-04e0-4b7e-970d-03ebedb7c2e7-8c0dd921-14f4-4f36-b681-c9bb580e7f20.yaml
+++ b/workloads/pvc-997b2378-04e0-4b7e-970d-03ebedb7c2e7-8c0dd921-14f4-4f36-b681-c9bb580e7f20.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-997b2378-04e0-4b7e-970d-03ebedb7c2e7
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: d788e453-b221-4fb9-bb94-8d1ef493bb69
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg1"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-997b2378-04e0-4b7e-970d-03ebedb7c2e7
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg1
+        selfLink: /api/v1/namespaces/pg1/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: 997b2378-04e0-4b7e-970d-03ebedb7c2e7
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: pg1
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 3Gi to 6Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
