### PR TITLE
[Autopilot] resize approval for pg1/pgbench-data (pvc-ef08d913-2a1b-4b0b-96c8-5930f88daf78) rule: volume-resize

### DIFF
--- a/workloads/pvc-ef08d913-2a1b-4b0b-96c8-5930f88daf78-7a74ce85-dc1c-4b62-84aa-995f66150aa8.yaml
+++ b/workloads/pvc-ef08d913-2a1b-4b0b-96c8-5930f88daf78-7a74ce85-dc1c-4b62-84aa-995f66150aa8.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-ef08d913-2a1b-4b0b-96c8-5930f88daf78
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: 0b41bb83-a4b1-4d4e-890b-d115a186d2e3
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg1"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-ef08d913-2a1b-4b0b-96c8-5930f88daf78
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg1
+        selfLink: /api/v1/namespaces/pg1/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: ef08d913-2a1b-4b0b-96c8-5930f88daf78
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: pg1
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 3Gi to 6Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
