### PR TITLE
[Autopilot] resize approval for pg2/pgbench-data (pvc-266850de-655d-4f68-8164-25e9b5a24d3d) rule: volume-resize

### DIFF
--- a/workloads/pvc-266850de-655d-4f68-8164-25e9b5a24d3d-26af5139-67d6-4a41-82a5-2fbc9f493427.yaml
+++ b/workloads/pvc-266850de-655d-4f68-8164-25e9b5a24d3d-26af5139-67d6-4a41-82a5-2fbc9f493427.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-266850de-655d-4f68-8164-25e9b5a24d3d
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: 8edc9a4d-8bfd-4557-a918-b1d2b0079e8a
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg2"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-266850de-655d-4f68-8164-25e9b5a24d3d
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg2
+        selfLink: /api/v1/namespaces/pg2/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: 266850de-655d-4f68-8164-25e9b5a24d3d
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}

--- a/workloads/pvc-266850de-655d-4f68-8164-25e9b5a24d3d-536fc932-6a4a-40a6-8e7a-d04abe726e58.yaml
+++ b/workloads/pvc-266850de-655d-4f68-8164-25e9b5a24d3d-536fc932-6a4a-40a6-8e7a-d04abe726e58.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-266850de-655d-4f68-8164-25e9b5a24d3d
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: 8edc9a4d-8bfd-4557-a918-b1d2b0079e8a
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg2"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-266850de-655d-4f68-8164-25e9b5a24d3d
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg2
+        selfLink: /api/v1/namespaces/pg2/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: 266850de-655d-4f68-8164-25e9b5a24d3d
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: pg2
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 3Gi to 6Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
