### PR TITLE
[Autopilot] resize approval for pg3/pgbench-data (pvc-7c1c96ae-8a5e-4f1f-86e8-87891a91dc6b) rule: volume-resize

### DIFF
--- a/workloads/pvc-7c1c96ae-8a5e-4f1f-86e8-87891a91dc6b-a540195c-ac2f-48d6-b641-9a4b096115b9.yaml
+++ b/workloads/pvc-7c1c96ae-8a5e-4f1f-86e8-87891a91dc6b-a540195c-ac2f-48d6-b641-9a4b096115b9.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-7c1c96ae-8a5e-4f1f-86e8-87891a91dc6b
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 498036b9-bd06-42cd-9e23-7bc51f4d9e93
+  uid: 6b17638e-7d78-49b8-b9b8-f26fe4c6ad69
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 3Gi to 6Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"pg3"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"3Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-7c1c96ae-8a5e-4f1f-86e8-87891a91dc6b
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: pg3
+        selfLink: /api/v1/namespaces/pg3/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: 7c1c96ae-8a5e-4f1f-86e8-87891a91dc6b
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: pg3
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 3Gi to 6Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
