### PR TITLE
[Autopilot] rebalance approval for Portworx storage pools (4af50815-8b9d-4ccb-939f-df7e9905f312) rule: pool-rebalance

### DIFF
--- a/workloads/4af50815-8b9d-4ccb-939f-df7e9905f312-f5697703-0050-4d0b-82f6-3056ea3c7d7c.yaml
+++ b/workloads/4af50815-8b9d-4ccb-939f-df7e9905f312-f5697703-0050-4d0b-82f6-3056ea3c7d7c.yaml
@@ -1,0 +1,50 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: pool-rebalance
+  name: 4af50815-8b9d-4ccb-939f-df7e9905f312
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: de3f93be-69b9-434e-b2e1-2a76dd87db55
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:30:51.394272811Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:30:51.394273827Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:30:51.870048263Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:30:51.870049347Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: StoragePool
- **Name**: Portworx storage pools
- **Namespace**: 
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312. Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c
Work summary:

Rebalance actions:

add replica
	Volume: 443639616480197746 
	Pool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 
	Node: c07e8b1c-ebf7-4eb5-b79c-185901da93f2 
	Replication set ID: 0 
	Start: 2020-05-28T00:30:51.394272811Z End: (timestamp: nil Timestamp)
	Work summary:
		-&gt; UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending
		-&gt; UnbalancedVolumes                  1 done, 0 pending

remove replica
	Volume: 443639616480197746 
	Pool: 4af50815-8b9d-4ccb-939f-df7e9905f312 
	Node: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a 
	Replication set ID: 0 
	Start: 2020-05-28T00:30:51.394273827Z End: (timestamp: nil Timestamp)
	Work summary:
		-&gt; UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending
		-&gt; UnbalancedVolumes                  1 done, 0 pending

add replica
	Volume: 34854947928731640 
	Pool: e570eadb-555e-41f2-8b05-fabd7717437c 
	Node: 46285b42-8b07-4a0f-b825-b9b4df7859cc 
	Replication set ID: 0 
	Start: 2020-05-28T00:30:51.870048263Z End: (timestamp: nil Timestamp)
	Work summary:
		-&gt; UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending
		-&gt; UnbalancedVolumes                  1 done, 0 pending

remove replica
	Volume: 34854947928731640 
	Pool: 4af50815-8b9d-4ccb-939f-df7e9905f312 
	Node: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a 
	Replication set ID: 0 
	Start: 2020-05-28T00:30:51.870049347Z End: (timestamp: nil Timestamp)
	Work summary:
		-&gt; UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending
		-&gt; UnbalancedVolumes                  1 done, 0 pending


### Why is the action needed.

The action request was triggered based on an AutopilotRule pool-rebalance defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
