### PR TITLE
[Autopilot] rebalance approval for Portworx storage pools (e570eadb-555e-41f2-8b05-fabd7717437c) rule: pool-rebalance

### DIFF
--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-0e9059a5-c5e0-4643-ab70-e380481be94a.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-0e9059a5-c5e0-4643-ab70-e380481be94a.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-1ce4151c-f86c-4cab-b75a-c412844954c4.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-1ce4151c-f86c-4cab-b75a-c412844954c4.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-1dc1a1a7-d6a2-4ec8-abcb-022068342196.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-1dc1a1a7-d6a2-4ec8-abcb-022068342196.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-269282a6-cc3b-4a37-b84d-0cdf018d8667.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-269282a6-cc3b-4a37-b84d-0cdf018d8667.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-280d529c-e38d-4abe-8b36-65955b30485b.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-280d529c-e38d-4abe-8b36-65955b30485b.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-2a13d909-a2a7-4e2c-ad1e-ea0a958508c6.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-2a13d909-a2a7-4e2c-ad1e-ea0a958508c6.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-47ae64f0-59b2-4a1e-89d5-6802730925f9.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-47ae64f0-59b2-4a1e-89d5-6802730925f9.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-547f8565-55f5-4d66-a2b8-e6b54bd3b482.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-547f8565-55f5-4d66-a2b8-e6b54bd3b482.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-612e887e-6f22-44ed-8c66-57d3c6cd9352.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-612e887e-6f22-44ed-8c66-57d3c6cd9352.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-61329f77-51c8-4a4f-8f36-ac2b14d1b5db.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-61329f77-51c8-4a4f-8f36-ac2b14d1b5db.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-6dc9dc03-667b-46a2-a75f-3d1739926dc7.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-6dc9dc03-667b-46a2-a75f-3d1739926dc7.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-7bae2d7b-006b-4aaf-a020-4749c496e0da.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-7bae2d7b-006b-4aaf-a020-4749c496e0da.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-87e325aa-1112-4d27-8e2f-cefeaa528ddf.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-87e325aa-1112-4d27-8e2f-cefeaa528ddf.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-8ce5f92d-73db-4cf6-b99d-875f390deaa2.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-8ce5f92d-73db-4cf6-b99d-875f390deaa2.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-9937ac2e-5d1c-4545-bb53-444cc9a340f7.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-9937ac2e-5d1c-4545-bb53-444cc9a340f7.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-b14b39df-ed0b-448c-9af5-7dbb0c935f58.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-b14b39df-ed0b-448c-9af5-7dbb0c935f58.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-c09fa6fc-57fb-4a48-8604-527a90466479.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-c09fa6fc-57fb-4a48-8604-527a90466479.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-c35d7d97-6372-47d1-a4a3-f69936a43d74.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-c35d7d97-6372-47d1-a4a3-f69936a43d74.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-cb828516-c0ef-4a6a-a5be-e0781f140119.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-cb828516-c0ef-4a6a-a5be-e0781f140119.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-ed95349e-8e2b-4f44-a609-33ab09326506.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-ed95349e-8e2b-4f44-a609-33ab09326506.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.354777943Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.35477899Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T01:02:19.82934088Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T01:02:19.829341859Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-f58298a1-e9ff-4306-88f4-1ed71236339d.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-f58298a1-e9ff-4306-88f4-1ed71236339d.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: ffe2920c-8ccc-4b97-b40a-dae13040cd19,e570eadb-555e-41f2-8b05-fabd7717437c\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 443639616480197746
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.355804325Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 443639616480197746 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.355805275Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:52:03.813250155Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:52:03.81325114Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}

--- a/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-f8f55925-cf8c-4769-a011-80e2ad621ce0.yaml
+++ b/workloads/e570eadb-555e-41f2-8b05-fabd7717437c-f8f55925-cf8c-4769-a011-80e2ad621ce0.yaml
@@ -1,0 +1,53 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  annotations:
+    fluxcd.io/sync-checksum: cbfaea1c8dc562a047fd5818a40919021019b862
+  creationTimestamp: null
+  labels:
+    fluxcd.io/sync-gc-mark: sha256.N78MBSEANAnkPDCdlQMSp8UcPjAZOOhfFd7R7liC5ug
+    rule: pool-rebalance
+  name: e570eadb-555e-41f2-8b05-fabd7717437c
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: pool-rebalance
+    uid: b167b073-dd58-4097-ba5c-d7f45fd98eec
+  uid: ddd12028-a193-4533-805b-10ec9f63dd00
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: "Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312.
+        Following pools are still under threshold: e570eadb-555e-41f2-8b05-fabd7717437c,ffe2920c-8ccc-4b97-b40a-dae13040cd19\nWork
+        summary:\n\nRebalance actions:\n\nadd replica\n\tVolume: 34854947928731640
+        \n\tPool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 \n\tNode: c07e8b1c-ebf7-4eb5-b79c-185901da93f2
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:41:48.366635107Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 34854947928731640 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:41:48.366636191Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n\nadd replica\n\tVolume: 983969232693426367
+        \n\tPool: e570eadb-555e-41f2-8b05-fabd7717437c \n\tNode: 46285b42-8b07-4a0f-b825-b9b4df7859cc
+        \n\tReplication set ID: 0 \n\tStart: 2020-05-28T00:41:48.742279746Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    9663676416
+        done, 0 pending\n\t\t-> UnbalancedVolumes                  1 done, 0 pending\n\nremove
+        replica\n\tVolume: 983969232693426367 \n\tPool: 4af50815-8b9d-4ccb-939f-df7e9905f312
+        \n\tNode: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a \n\tReplication set ID: 0 \n\tStart:
+        2020-05-28T00:41:48.742280967Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending\n\t\t-> UnbalancedVolumes
+        \                 1 done, 0 pending\n"
+      name: openstorage.io.action.storagepool/rebalance
+      objectMetadata:
+        annotations:
+          rule: pool-rebalance
+          ruleobject: e570eadb-555e-41f2-8b05-fabd7717437c
+        creationTimestamp: null
+        name: Portworx storage pools
+        type: StoragePool
+      params: {}
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: StoragePool
- **Name**: Portworx storage pools
- **Namespace**: 
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

Error: following pools are still above threshold: 4af50815-8b9d-4ccb-939f-df7e9905f312. Following pools are still under threshold: e570eadb-555e-41f2-8b05-fabd7717437c,ffe2920c-8ccc-4b97-b40a-dae13040cd19
Work summary:

Rebalance actions:

add replica
	Volume: 34854947928731640 
	Pool: ffe2920c-8ccc-4b97-b40a-dae13040cd19 
	Node: c07e8b1c-ebf7-4eb5-b79c-185901da93f2 
	Replication set ID: 0 
	Start: 2020-05-28T00:41:48.366635107Z End: (timestamp: nil Timestamp)
	Work summary:
		-&gt; UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending
		-&gt; UnbalancedVolumes                  1 done, 0 pending

remove replica
	Volume: 34854947928731640 
	Pool: 4af50815-8b9d-4ccb-939f-df7e9905f312 
	Node: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a 
	Replication set ID: 0 
	Start: 2020-05-28T00:41:48.366636191Z End: (timestamp: nil Timestamp)
	Work summary:
		-&gt; UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending
		-&gt; UnbalancedVolumes                  1 done, 0 pending

add replica
	Volume: 983969232693426367 
	Pool: e570eadb-555e-41f2-8b05-fabd7717437c 
	Node: 46285b42-8b07-4a0f-b825-b9b4df7859cc 
	Replication set ID: 0 
	Start: 2020-05-28T00:41:48.742279746Z End: (timestamp: nil Timestamp)
	Work summary:
		-&gt; UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending
		-&gt; UnbalancedVolumes                  1 done, 0 pending

remove replica
	Volume: 983969232693426367 
	Pool: 4af50815-8b9d-4ccb-939f-df7e9905f312 
	Node: c6d3882e-c8d8-41d2-bfac-3c7b6e0cd67a 
	Replication set ID: 0 
	Start: 2020-05-28T00:41:48.742280967Z End: (timestamp: nil Timestamp)
	Work summary:
		-&gt; UnbalancedProvisionedSpaceBytes    9663676416 done, 0 pending
		-&gt; UnbalancedVolumes                  1 done, 0 pending


### Why is the action needed.

The action request was triggered based on an AutopilotRule pool-rebalance defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
