### PR TITLE
[Autopilot] resize approval for default/pgbench-data (pvc-87e71849-756a-46e2-9151-f46dbee27acb) rule: volume-resize

### DIFF
--- a/workloads/pvc-87e71849-756a-46e2-9151-f46dbee27acb-72d1f319-b0f7-4d9f-8c23-1ba692b249db.yaml
+++ b/workloads/pvc-87e71849-756a-46e2-9151-f46dbee27acb-72d1f319-b0f7-4d9f-8c23-1ba692b249db.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-87e71849-756a-46e2-9151-f46dbee27acb
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 787b040c-a67a-4eae-8fac-4aa53bde01a9
+  uid: 17ccb40a-f360-4db3-b310-6b6c5f9628c6
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 9Gi to 18Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"default"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"9Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-87e71849-756a-46e2-9151-f46dbee27acb
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: default
+        selfLink: /api/v1/namespaces/default/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: 87e71849-756a-46e2-9151-f46dbee27acb
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: default
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 9Gi to 18Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
