### PR TITLE
[Autopilot] resize approval for default/pgbench-data (pvc-87e71849-756a-46e2-9151-f46dbee27acb) rule: volume-resize

### DIFF
--- a/workloads/pvc-87e71849-756a-46e2-9151-f46dbee27acb-05030628-7797-40db-891c-11917d51dd11.yaml
+++ b/workloads/pvc-87e71849-756a-46e2-9151-f46dbee27acb-05030628-7797-40db-891c-11917d51dd11.yaml
@@ -1,0 +1,39 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-87e71849-756a-46e2-9151-f46dbee27acb
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 8dcf82cb-48d8-48f1-b88a-192f9737e37d
+  uid: f6715fcb-d416-4b84-a277-19d29b103694
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 9Gi to 18Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"default"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"9Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-87e71849-756a-46e2-9151-f46dbee27acb
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: default
+        selfLink: /api/v1/namespaces/default/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: 87e71849-756a-46e2-9151-f46dbee27acb
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: default
- **Owner information**:
    - **Type**: 
    - **Name**: 

### What action will be taken

PVC will resize from 9Gi to 18Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
