### PR TITLE
[Autopilot] resize approval for default/pgbench-data (pvc-d6e8b973-d12d-4729-aa28-a6f7f393a1a1) rule: volume-resize

### DIFF
--- a/workloads/pvc-d6e8b973-d12d-4729-aa28-a6f7f393a1a1-7ca77b7d-9124-4ecc-b440-b26ac8867c00.yaml
+++ b/workloads/pvc-d6e8b973-d12d-4729-aa28-a6f7f393a1a1-7ca77b7d-9124-4ecc-b440-b26ac8867c00.yaml
@@ -1,0 +1,46 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: AutopilotRuleObject
+metadata:
+  creationTimestamp: null
+  labels:
+    rule: volume-resize
+  name: pvc-d6e8b973-d12d-4729-aa28-a6f7f393a1a1
+  ownerReferences:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: AutopilotRule
+    name: volume-resize
+    uid: 1e57568d-367b-49fe-ae7f-4cec2735f3c7
+  uid: b3207dd7-e148-45d2-8d8e-c7cb66484656
+spec:
+  actionApprovals:
+  - action:
+      expectedResult: PVC will resize from 30Gi to 60Gi
+      name: openstorage.io.action.volume/resize
+      objectMetadata:
+        annotations:
+          kubectl.kubernetes.io/last-applied-configuration: |
+            {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"app":"postgres"},"name":"pgbench-data","namespace":"default"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"30Gi"}},"storageClassName":"postgres-pgbench-sc"}}
+          rule: volume-resize
+          ruleobject: pvc-d6e8b973-d12d-4729-aa28-a6f7f393a1a1
+          volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/portworx-volume
+        creationTimestamp: null
+        labels:
+          app: postgres
+        name: pgbench-data
+        namespace: default
+        ownerReferences:
+        - apiVersion: apps/v1
+          blockOwnerDeletion: true
+          controller: true
+          kind: ReplicaSet
+          name: pgbench-5f84f5b884
+          uid: 847043e9-0f98-4daf-8752-2e96c441a430
+        selfLink: /api/v1/namespaces/default/persistentvolumeclaims/pgbench-data
+        type: PersistentVolumeClaim
+        uid: d6e8b973-d12d-4729-aa28-a6f7f393a1a1
+      params:
+        scalepercentage: "100"
+    state: approved
+status: {}


### PR DESCRIPTION


This is a request to approve the following automated autopilot action

### What will get affected

- **Type**: PersistentVolumeClaim
- **Name**: pgbench-data
- **Namespace**: default
- **Owner information**:
    - **Type**: ReplicaSet
    - **Name**: pgbench-5f84f5b884

### What action will be taken

PVC will resize from 30Gi to 60Gi

### Why is the action needed.

The action request was triggered based on an AutopilotRule volume-resize defined in your cluster.

### How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
