### PR TITLE
[Autopilot] approval for rule kube-system/pool-rebalance-4a8ec973-219b-48da-b0a1-b3f45e843789 rule: pool-rebalance

### DIFF
--- a/workloads/pool-rebalance-4a8ec973-219b-48da-b0a1-b3f45e843789-3984d7cd-1556-45c6-94ad-37b25321d7f6.yaml
+++ b/workloads/pool-rebalance-4a8ec973-219b-48da-b0a1-b3f45e843789-3984d7cd-1556-45c6-94ad-37b25321d7f6.yaml
@@ -1,0 +1,20 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    object: 4a8ec973-219b-48da-b0a1-b3f45e843789
+    rule: pool-rebalance
+  name: pool-rebalance-4a8ec973-219b-48da-b0a1-b3f45e843789
+  namespace: kube-system
+  uid: 82f63d19-351f-4a21-89da-fa7cc9b5fcd9
+spec:
+  actions:
+  - name: rebalance
+    params: null
+  approvalState: approved
+status:
+  Rule:
+    Name: ""
+    Namespace: ""
+  lastProcessTimestamp: null


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __pool-rebalance__ defined in your cluster.


## What actions will be taken

### Action: rebalance

 
#### What objects will get affected

- StoragePool kube-system/4a8ec973-219b-48da-b0a1-b3f45e843789 (4a8ec973-219b-48da-b0a1-b3f45e843789)
  - Object Owner(s):
    -  portworx cluster: harsh-pks-demo-38  
- StoragePool kube-system/e24c4dbe-4f80-48db-8a1d-17ae2e459fcc (e24c4dbe-4f80-48db-8a1d-17ae2e459fcc)
  - Object Owner(s):
    -  portworx cluster: harsh-pks-demo-38  
- StoragePool kube-system/44fbba64-4b10-4fa4-974b-b6dcf491ed11 (44fbba64-4b10-4fa4-974b-b6dcf491ed11)
  - Object Owner(s):
    -  portworx cluster: harsh-pks-demo-38      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
