### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-9de7d1a3-cd38-4d90-a54e-a458fce31ace rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-9de7d1a3-cd38-4d90-a54e-a458fce31ace-d29383f2-cfe6-4973-902d-d2fddb94a053.yaml
+++ b/workloads/volume-resize-pvc-9de7d1a3-cd38-4d90-a54e-a458fce31ace-d29383f2-cfe6-4973-902d-d2fddb94a053.yaml
@@ -1,0 +1,22 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    object: pvc-9de7d1a3-cd38-4d90-a54e-a458fce31ace
+    rule: volume-resize
+  name: volume-resize-pvc-9de7d1a3-cd38-4d90-a54e-a458fce31ace
+  namespace: pg1
+  uid: 02d06fd9-fc4b-4130-a025-965fc4395eaf
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: ""
+    Namespace: ""
+  lastProcessTimestamp: null


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]
- __ExpectedResult__: PVC will resize from 20Gi to 40Gi

 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-9de7d1a3-cd38-4d90-a54e-a458fce31ace)
  - Object Owner(s):
    - ReplicaSet pgbench-7f64fc8444      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
