### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-ec475444-e2d6-4533-863b-03263da7b04c rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-ec475444-e2d6-4533-863b-03263da7b04c-e8f9410e-5407-4a0d-b93b-70f25b40dd21.yaml
+++ b/workloads/volume-resize-pvc-ec475444-e2d6-4533-863b-03263da7b04c-e8f9410e-5407-4a0d-b93b-70f25b40dd21.yaml
@@ -1,0 +1,42 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    object: pvc-ec475444-e2d6-4533-863b-03263da7b04c
+    rule: volume-resize
+  name: volume-resize-pvc-ec475444-e2d6-4533-863b-03263da7b04c
+  namespace: pg1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 20Gi to 40Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pg1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-7f64fc8444
+        uid: 2ac06424-f802-4d53-8342-e302846aceef
+      uid: pvc-ec475444-e2d6-4533-863b-03263da7b04c
+  lastProcessTimestamp: "2020-08-25T23:27:24Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]
- __ExpectedResult__: PVC will resize from 20Gi to 40Gi

 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-ec475444-e2d6-4533-863b-03263da7b04c)
  - Object Owner(s):
    - ReplicaSet pgbench-7f64fc8444      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
