### PR TITLE
[Autopilot] approval for rule kube-system/pool-rebalance-e24c4dbe-4f80-48db-8a1d-17ae2e459fcc rule: pool-rebalance

### DIFF
--- a/workloads/pool-rebalance-e24c4dbe-4f80-48db-8a1d-17ae2e459fcc-e43a46c0-b2b4-48b2-b4c9-f1d28f2e6869.yaml
+++ b/workloads/pool-rebalance-e24c4dbe-4f80-48db-8a1d-17ae2e459fcc-e43a46c0-b2b4-48b2-b4c9-f1d28f2e6869.yaml
@@ -1,0 +1,76 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    object: e24c4dbe-4f80-48db-8a1d-17ae2e459fcc
+    rule: pool-rebalance
+  name: pool-rebalance-e24c4dbe-4f80-48db-8a1d-17ae2e459fcc
+  namespace: kube-system
+spec:
+  actions:
+  - name: rebalance
+    params: null
+  approvalState: approved
+status:
+  Rule:
+    Name: pool-rebalance
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: rebalance
+      params: null
+    expectedResult:
+      Message: "Rebalance summary:\n\t-> UnbalancedProvisionedSpaceBytes    0 done,
+        64424509440 pending\n\t-> UnbalancedVolumes                  0 done, 2 pending\n\nRebalance
+        actions:\n\nadd replica\n\tVolume: 471990147784054698 \n\tPool: 4a8ec973-219b-48da-b0a1-b3f45e843789
+        \n\tNode: 6eec1f0a-2679-41a7-a541-bc5f9dec52d9 \n\tReplication set ID: 0 \n\tStart:
+        2020-08-27T19:27:37.834777251Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    0 done, 32212254720 pending\n\t\t-> UnbalancedVolumes
+        \                 0 done, 1 pending\n\nremove replica\n\tVolume: 471990147784054698
+        \n\tPool: e24c4dbe-4f80-48db-8a1d-17ae2e459fcc \n\tNode: 366acf86-96ec-499c-913d-f5455b1860a9
+        \n\tReplication set ID: 0 \n\tStart: 2020-08-27T19:27:37.834780431Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    0
+        done, 32212254720 pending\n\t\t-> UnbalancedVolumes                  0 done,
+        1 pending\n\nadd replica\n\tVolume: 637700901175754276 \n\tPool: 44fbba64-4b10-4fa4-974b-b6dcf491ed11
+        \n\tNode: a53dbf82-faca-40a2-a7bc-3f1c397f1516 \n\tReplication set ID: 0 \n\tStart:
+        2020-08-27T19:27:37.86697071Z End: (timestamp: nil Timestamp)\n\tWork summary:\n\t\t->
+        UnbalancedProvisionedSpaceBytes    0 done, 32212254720 pending\n\t\t-> UnbalancedVolumes
+        \                 0 done, 1 pending\n\nremove replica\n\tVolume: 637700901175754276
+        \n\tPool: e24c4dbe-4f80-48db-8a1d-17ae2e459fcc \n\tNode: 366acf86-96ec-499c-913d-f5455b1860a9
+        \n\tReplication set ID: 0 \n\tStart: 2020-08-27T19:27:37.866973769Z End: (timestamp:
+        nil Timestamp)\n\tWork summary:\n\t\t-> UnbalancedProvisionedSpaceBytes    0
+        done, 32212254720 pending\n\t\t-> UnbalancedVolumes                  0 done,
+        1 pending\n"
+    involvedObjects:
+    - apiVersion: ""
+      kind: StoragePool
+      name: 4a8ec973-219b-48da-b0a1-b3f45e843789
+      namespace: kube-system
+      ownerReferences:
+      - apiVersion: ""
+        kind: ""
+        name: 'portworx cluster: harsh-pks-demo-38'
+        uid: ea4270d3-391d-4ae8-92c2-68e12d39a145
+      uid: 4a8ec973-219b-48da-b0a1-b3f45e843789
+    - apiVersion: ""
+      kind: StoragePool
+      name: e24c4dbe-4f80-48db-8a1d-17ae2e459fcc
+      namespace: kube-system
+      ownerReferences:
+      - apiVersion: ""
+        kind: ""
+        name: 'portworx cluster: harsh-pks-demo-38'
+        uid: ea4270d3-391d-4ae8-92c2-68e12d39a145
+      uid: e24c4dbe-4f80-48db-8a1d-17ae2e459fcc
+    - apiVersion: ""
+      kind: StoragePool
+      name: 44fbba64-4b10-4fa4-974b-b6dcf491ed11
+      namespace: kube-system
+      ownerReferences:
+      - apiVersion: ""
+        kind: ""
+        name: 'portworx cluster: harsh-pks-demo-38'
+        uid: ea4270d3-391d-4ae8-92c2-68e12d39a145
+      uid: 44fbba64-4b10-4fa4-974b-b6dcf491ed11
+  lastProcessTimestamp: "2020-08-27T19:27:37Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __pool-rebalance__ defined in your cluster.


## What actions will be taken

### Action: rebalance

 
#### What objects will get affected

- StoragePool kube-system/4a8ec973-219b-48da-b0a1-b3f45e843789 (4a8ec973-219b-48da-b0a1-b3f45e843789)
  - Object Owner(s):
    -  portworx cluster: harsh-pks-demo-38  
- StoragePool kube-system/e24c4dbe-4f80-48db-8a1d-17ae2e459fcc (e24c4dbe-4f80-48db-8a1d-17ae2e459fcc)
  - Object Owner(s):
    -  portworx cluster: harsh-pks-demo-38  
- StoragePool kube-system/44fbba64-4b10-4fa4-974b-b6dcf491ed11 (44fbba64-4b10-4fa4-974b-b6dcf491ed11)
  - Object Owner(s):
    -  portworx cluster: harsh-pks-demo-38      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
