### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-d2a02fcc-5c83-4eac-8c65-96c216275b06 rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-d2a02fcc-5c83-4eac-8c65-96c216275b06-8962941f-dc5d-4853-8708-3faabb17ad1d.yaml
+++ b/workloads/volume-resize-pvc-d2a02fcc-5c83-4eac-8c65-96c216275b06-8962941f-dc5d-4853-8708-3faabb17ad1d.yaml
@@ -1,0 +1,42 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    object: pvc-d2a02fcc-5c83-4eac-8c65-96c216275b06
+    rule: volume-resize
+  name: volume-resize-pvc-d2a02fcc-5c83-4eac-8c65-96c216275b06
+  namespace: pg1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 20Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pg1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-7f64fc8444
+        uid: 98c81487-924a-400f-8549-7ee3a05c168a
+      uid: pvc-d2a02fcc-5c83-4eac-8c65-96c216275b06
+  lastProcessTimestamp: "2020-08-27T22:47:48Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]
- __ExpectedResult__: PVC will resize from 10Gi to 20Gi

 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-d2a02fcc-5c83-4eac-8c65-96c216275b06)
  - Object Owner(s):
    - ReplicaSet pgbench-7f64fc8444      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
