### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-d108475a-d6cb-4e91-b002-f7bf178c4cac rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-d108475a-d6cb-4e91-b002-f7bf178c4cac-bfa02fde-3710-487f-835e-6fd24a3498c5.yaml
+++ b/workloads/volume-resize-pvc-d108475a-d6cb-4e91-b002-f7bf178c4cac-bfa02fde-3710-487f-835e-6fd24a3498c5.yaml
@@ -1,0 +1,42 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    object: pvc-d108475a-d6cb-4e91-b002-f7bf178c4cac
+    rule: volume-resize
+  name: volume-resize-pvc-d108475a-d6cb-4e91-b002-f7bf178c4cac
+  namespace: pg1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 20Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pg1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-7f64fc8444
+        uid: dde9e6e0-cce1-4210-acd0-1909d995dc92
+      uid: pvc-d108475a-d6cb-4e91-b002-f7bf178c4cac
+  lastProcessTimestamp: "2020-08-27T23:27:42Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]
- __ExpectedResult__: PVC will resize from 10Gi to 20Gi

 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-d108475a-d6cb-4e91-b002-f7bf178c4cac)
  - Object Owner(s):
    - ReplicaSet pgbench-7f64fc8444      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
