### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-f338e520-1cc0-48b9-8d8f-f6e8db5b7955 rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-f338e520-1cc0-48b9-8d8f-f6e8db5b7955-bb96a9f2-b183-47cf-8c1e-98051d1e80fa.yaml
+++ b/workloads/volume-resize-pvc-f338e520-1cc0-48b9-8d8f-f6e8db5b7955-bb96a9f2-b183-47cf-8c1e-98051d1e80fa.yaml
@@ -1,0 +1,42 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  labels:
+    object: pvc-f338e520-1cc0-48b9-8d8f-f6e8db5b7955
+    rule: volume-resize
+  name: volume-resize-pvc-f338e520-1cc0-48b9-8d8f-f6e8db5b7955
+  namespace: pg1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 20Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pg1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-7f64fc8444
+        uid: c4a0e23f-a968-4c54-9c87-7d02768d3be9
+      uid: pvc-f338e520-1cc0-48b9-8d8f-f6e8db5b7955
+  lastProcessTimestamp: "2020-08-27T23:45:41Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]
- __ExpectedResult__: PVC will resize from 10Gi to 20Gi

 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-f338e520-1cc0-48b9-8d8f-f6e8db5b7955)
  - Object Owner(s):
    - ReplicaSet pgbench-7f64fc8444      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
