### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-76bba761-885d-4a38-9af8-d0dac70478b8 rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-76bba761-885d-4a38-9af8-d0dac70478b8-ed24780a-e705-4d38-9b65-f4424d28b576.yaml
+++ b/workloads/volume-resize-pvc-76bba761-885d-4a38-9af8-d0dac70478b8-ed24780a-e705-4d38-9b65-f4424d28b576.yaml
@@ -1,0 +1,44 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-76bba761-885d-4a38-9af8-d0dac70478b8
+    rule: volume-resize
+  name: volume-resize-pvc-76bba761-885d-4a38-9af8-d0dac70478b8
+  namespace: pg1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 20Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pg1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-7f64fc8444
+        uid: 24fa7967-7df9-43f4-810b-f0fab6411326
+      uid: pvc-76bba761-885d-4a38-9af8-d0dac70478b8
+  lastProcessTimestamp: "2020-08-28T00:28:06Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]
- __ExpectedResult__: PVC will resize from 10Gi to 20Gi

 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-76bba761-885d-4a38-9af8-d0dac70478b8)
  - Object Owner(s):
    - ReplicaSet pgbench-7f64fc8444      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
