### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-07858e2c-6208-473d-81df-130c8157f66d rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-07858e2c-6208-473d-81df-130c8157f66d-6f838a5c-2cf6-4134-8595-f9c2e7e962d4.yaml
+++ b/workloads/volume-resize-pvc-07858e2c-6208-473d-81df-130c8157f66d-6f838a5c-2cf6-4134-8595-f9c2e7e962d4.yaml
@@ -1,0 +1,44 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-07858e2c-6208-473d-81df-130c8157f66d
+    rule: volume-resize
+  name: volume-resize-pvc-07858e2c-6208-473d-81df-130c8157f66d
+  namespace: pg1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 20Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pg1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-7f64fc8444
+        uid: 7c878856-fcaa-4f6b-ad44-135caacdeeb6
+      uid: pvc-07858e2c-6208-473d-81df-130c8157f66d
+  lastProcessTimestamp: "2020-08-28T01:53:43Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]
- __ExpectedResult__: PVC will resize from 10Gi to 20Gi

 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-07858e2c-6208-473d-81df-130c8157f66d)
  - Object Owner(s):
    - ReplicaSet pgbench-7f64fc8444      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
